### PR TITLE
Set TravisCI badge to track master branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 NGCP Ground Control Station
 ===========================
 
-.. image:: https://travis-ci.com/NGCP/GCS.svg
+.. image:: https://travis-ci.com/NGCP/GCS.svg?branch=master
   :target: https://travis-ci.com/NGCP/GCS
   :alt: Build Status
 


### PR DESCRIPTION
Before this PR, the badge tracks any branch build, when it should only look at the `master` branch.

This PR will make the badge track only the latest build in `master`.