### PR TITLE
Merge docs script into one npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GCS",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "MIT",
   "author": "Northrop Grumman Collaboration Project",
   "description": "Ground Control Station for autonomous vehicle platforms in NGCP",
@@ -13,8 +13,7 @@
     "test:unit": "mocha --require ts-node/register test/**/*.test.ts",
     "lint": "eslint --fix --ext .js,.jsx,.ts,.tsx \".\" && stylelint \"**/*.css\" --fix",
     "start": "electron-webpack dev",
-    "start:windocs": "explorer http://localhost:8000/ & sphinx-autobuild docs docs/_build/html",
-    "start:macdocs": "open http://localhost:8000/ & sphinx-autobuild docs docs/_build/html",
+    "docs": "(explorer http://localhost:8000/ || open http://localhost:8000/) & sphinx-autobuild docs docs/_build/html",
     "build": "electron-webpack && electron-builder"
   },
   "dependencies": {


### PR DESCRIPTION
 ## Why is the change being made?

This change is made because the scripts for running docs (one was for
Windows and the other for macOS) was redundant.

 ## What has changed to address the problem?

This change merges the scripts into one script. `npm run start:windocs`
and `npm run start:macdocs` is now merged to `npm run docs` and should
work.

 ## How was this change tested?

This change was tested with `npm run docs` on Windows. This has not been
tested on macOS or Linux, but I am confident that it works too.