### PR TITLE
Add geofencing message structure

### DIFF
--- a/src/common/struct/Vehicle.ts
+++ b/src/common/struct/Vehicle.ts
@@ -260,6 +260,11 @@ export default class Vehicle {
     this.sendMessage({
       type: 'start',
       jobType,
+      geofence: {
+        topLeft: [0, 0],
+        botRight: [0, 0],
+        keepOut: true,
+      },
     });
 
     this.updateEventHandler.addHandler<VehicleStatus>('status', (value): boolean => {

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -28,6 +28,28 @@ export interface StartMessage extends MessageBase {
    * Name of job to perform.
    */
   jobType: JobType;
+
+  /**
+    * Geofencing coordinates in the form of a rectangle, and geofence type sent with start message.
+    */
+  geofence: {
+
+    /**
+     * Top Left coordinate of geofencing rectangle, in form of latitude, longitude.
+     */
+    topLeft: [number, number];
+
+    /**
+     * Bottom right coordinate of geofencing rectangle, in form of latitude, longitude.
+     */
+    botRight: [number, number];
+
+    /**
+     * Boolean to specify whether geofence is keep out type (true), or keep in type (false).
+     */
+    keepOut: boolean;
+  };
+
 }
 
 /**


### PR DESCRIPTION
 ## Why is the change being made?

This change is made to add geofencing to the start mission messages to the vehicles.

 ## What has changed to address the problem?

This change adds geofencing type to the start message in message.ts. Additionally, a default placeholder for Vehicle.ts is added as well.

 ## How was this change tested?

This change was tested with npm test.