### PR TITLE
Add coverage through istanbul + coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 package-lock.json
 
 # Ignore generated folders
+.nyc_output
 dist
 node_modules
 site

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ cache: npm
 # Scripts to run to test application
 script:
   - npm test
+
+# Run coverage after tests pass
+after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.com/NGCP/GCS.svg?branch=master)](https://travis-ci.com/NGCP/GCS)
 [![Documentation Status](https://readthedocs.org/projects/ground-control-station/badge/?version=latest)](https://readthedocs.org/projects/ground-control-station/builds/)
+[![Coverage Status](https://coveralls.io/repos/github/NGCP/GCS/badge.svg?branch=master)](https://coveralls.io/github/NGCP/GCS?branch=master)
 [![dependencies Status](https://david-dm.org/NGCP/GCS/status.svg)](https://david-dm.org/NGCP/GCS)
 [![devDependencies Status](https://david-dm.org/NGCP/GCS/dev-status.svg)](https://david-dm.org/NGCP/GCS?type=dev)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GCS",
-  "version": "0.10.2",
+  "version": "0.11.2",
   "license": "MIT",
   "author": "Northrop Grumman Collaboration Project",
   "description": "Ground Control Station for autonomous vehicle platforms in NGCP",
@@ -13,7 +13,8 @@
     "test:stylelint": "stylelint \"**/*.css\"",
     "test:remarklint": "remark .",
     "test:types": "tsc --project . --outDir dist --pretty",
-    "test:unit": "mocha --require ts-node/register test/**/*.test.ts",
+    "test:unit": "nyc mocha --require ts-node/register test/**/*.test.ts",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "start": "electron-webpack dev",
     "docs": "mkdocs serve",
     "build": "electron-webpack && electron-builder"
@@ -50,6 +51,7 @@
     "@typescript-eslint/parser": "^2.19.0",
     "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",
+    "coveralls": "^3.0.9",
     "dotenv-webpack": "^1.7.0",
     "electron": "^3",
     "electron-builder": "^22.3.2",
@@ -65,6 +67,7 @@
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^1.7",
     "mocha": "^7.0.1",
+    "nyc": "^15.0.0",
     "remark-cli": "^7.0.1",
     "remark-preset-lint-markdown-style-guide": "^2.1.3",
     "stylelint": "^13.1.0",


### PR DESCRIPTION
 ## Why is the change being made?

This change is made because GCS has no coverage currently. It is
important to have coverage in code to see how much code is actually
unit tested.

 ## What has changed to address the problem?

This change adds coverage to the code. The coverage right now is pretty
bad but it can always be improved in the future.

This change adds module dependencies to get and report coverage, puts
a coverage badge on our README and adds coverage build files to the
`.gitignore` file.

 ## How was this change tested?

This change was tested with `npm test`.

 ## Related documents, URLs, commits

Fixes #99 