### PR TITLE
Update Travis CI to add webhooks and remove cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,15 @@ language: node_js
 node_js:
   - lts/*
 
-# Cache node_modules after testing
-cache: npm
-
 # Scripts to run to test application
 script:
   - npm test
 
-# Run coverage after tests pass
-after_success: npm run coverage
+# Scripts to run after build success/failure
+after_success:
+  - npm run coverage
+  - chmod +x script/webhook.sh
+  - ./script/webhook.sh success
+after_failure:
+  - chmod +x script/webhook.sh
+  - ./script/webhook.sh failure

--- a/script/webhook.sh
+++ b/script/webhook.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z $1 ]; then
+  echo "ERROR: Expecting an argument (success/failure) but got none"
+  exit 1
+fi
+
+if [[ $TRAVIS_BRANCH != 'webhook' ]]; then
+  echo "INFO: Not the master branch, will not send webhook"
+  exit 0
+fi
+
+echo "INFO: On master branch, sending webhook"
+wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+chmod +x send.sh
+./send.sh $1 $WEBHOOK_URL

--- a/script/webhook.sh
+++ b/script/webhook.sh
@@ -10,6 +10,11 @@ if [[ $TRAVIS_BRANCH != 'master' ]]; then
   exit 0
 fi
 
+if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
+  echo "INFO: Build is a pull request build, will not send webhook"
+  exit 0
+fi
+
 echo "INFO: On master branch, sending webhook"
 wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
 chmod +x send.sh

--- a/script/webhook.sh
+++ b/script/webhook.sh
@@ -5,7 +5,7 @@ if [ -z $1 ]; then
   exit 1
 fi
 
-if [[ $TRAVIS_BRANCH != 'webhook' ]]; then
+if [[ $TRAVIS_BRANCH != 'master' ]]; then
   echo "INFO: Not the master branch, will not send webhook"
   exit 0
 fi


### PR DESCRIPTION
 ## Why is the change being made?

This change is made because webhooks from GitHub to Discord was annoying
with pushes/pull requests/etc and was not necessary. The necessary
update to developers is the build status of the `master` branch.

This change also addresses the fact that a build has failed to succeed
due to an invalid cache.

 ## What has changed to address the problem?

This change will add a script that will run another script that sends a
webhook of the build. The webhook URL has to be set up in Discord, and
made an environmental variable in Travis CI to work.

 ## How was this change tested?

This change will be tested by making the `webhook` branch emit to
Discord and see if it goes through successfully. Then the emitting
branch will be changed to `master`.

Also, the cache was removed from `.travis.yml`.

 ## Related documents, URLs, commits

Webhook script: https://github.com/DiscordHooks/travis-ci-discord-webhook#guide

Travis CI environmental variables: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables