### PR TITLE
Allow GCS to use latest version of electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "GCS",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "license": "MIT",
   "author": "Northrop Grumman Collaboration Project",
   "description": "Ground Control Station for autonomous vehicle platforms in NGCP",
   "repository": "https://github.com/NGCP/GCS",
   "scripts": {
-    "postinstall": "electron-rebuild",
+    "postinstall": "electron-builder install-app-deps",
     "test": "npm run test:lint && npm run test:types && npm run test:unit",
     "test:lint": "npm run test:eslint && npm run test:stylelint && npm run test:remarklint",
     "test:eslint": "eslint --ext .js,.jsx,.ts,.tsx \".\"",
@@ -41,6 +41,7 @@
     "@types/chai": "^4.2.8",
     "@types/mocha": "^7.0.1",
     "@types/msgpack-lite": "^0.1.7",
+    "@types/node": "^12.12.29",
     "@types/rc-slider": "^8.6.5",
     "@types/react": "^16.9.19",
     "@types/react-dom": "^16.9.5",
@@ -53,9 +54,8 @@
     "chai": "^4.2.0",
     "coveralls": "^3.0.9",
     "dotenv-webpack": "^1.7.0",
-    "electron": "^3",
+    "electron": "^8.0.3",
     "electron-builder": "^22.3.2",
-    "electron-rebuild": "^1.10.0",
     "electron-webpack": "^2.7.4",
     "electron-webpack-ts": "^3.2.0",
     "eslint": "^6.8.0",
@@ -76,9 +76,6 @@
     "ts-node": "^8.6.2",
     "typescript": "^3.7.5",
     "webpack": "^4.41.5"
-  },
-  "build": {
-    "npmRebuild": false
   },
   "electronWebpack": {
     "main": {


### PR DESCRIPTION
## Why is the change being made?

This change is made because GCS was running on electron v3, a version
made back two years ago. This version is long deprecated and GCS needed
to upgrade to v8 sooner or later. However, electron v5 would not build
at all (we dont consider v4 as it does not support geolocation).

## What has changed to address the problem?

This change finds the issue to be the fact electron v5+ turns off the
`nodeIntegration` field for windows (used to be on by default). This was
breaking our application.

This change sets `nodeIntegration` to true for all windows created, and
updates electron to v8. Other related fields that were modified from v3
to v8 are updated in this change.

Other minor changes are the following:
- removing dependency on `electron-rebuild` and setting `preinstall` script
to `electron-builder install-app-deps` in `package.json`
- removing `build` field in `package.json` as `electron-rebuild` is no
longer a dependency
- added dependency to `@types/node` v12 as default version v13 breaks tests with
electron v8 (see https://github.com/electron/electron/issues/21612)

## How was this change tested?

This change was tested with `npm test`, running the application and
seeing if it was fine, and running the application from `npm run build`
and seeing if it was fine (checking console, build status, and if
serialport runs).

## Related documents, URLs, commits

https://github.com/electron/electron/releases/tag/v5.0.0