### PR TITLE
Add script to test build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js:
 # Scripts to run to test application
 script:
   - npm test
+  - npm run build
 
 # Scripts to run after build success/failure
 after_success:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GCS",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "MIT",
   "author": "Northrop Grumman Collaboration Project",
   "description": "Ground Control Station for autonomous vehicle platforms in NGCP",


### PR DESCRIPTION
 ## Why is the change being made?

This change is made because it is important for Travis to see if the
build works by running the build script and seeing if it passes.

 ## What has changed to address the problem?

This change adds `npm run build` to Travis's test scripts.

 ## How was this change tested?

This test will be tested through Travis. A GH_TOKEN environment variable
will be provided to Travis for the build to pass.

 ## Related documents, URLs, commits