### PR TITLE
Add GeofenceMessage to gcs-vehicles-messages.md 

### DIFF
--- a/docs/communications/messages/gcs-vehicles-messages.md
+++ b/docs/communications/messages/gcs-vehicles-messages.md
@@ -35,28 +35,12 @@ Sent to the vehicle to assign a job to complete a mission.
   "tid": <unsigned 32-bit integer>,
   "time": <unsigned 64-bit integer>,
   "jobType": <string>,
-  "geofence": {
-    "topLeft": [<float>, <float>],
-    "botRight": [<float>, <float>],
-    "keepOut": <boolean>
-  }
 }
 ```
 
   - **jobType : string**
-      - Job being assigned to the vehicle to in order to complete the vehicle. This vehicle is
+      - Job being assigned to the vehicle to in order to complete the mission. This vehicle is
       capable of doing the job.
-
-  - **geofence**
-      - **topLeft : float[]**
-          - Array of structure `[latitude, longitude]` for top left corner of geofencing.
-
-      - **botRight : float[]**
-          - Array of structure `[latitude, longitude]` for bottom right corner of geofencing.
-
-      - **keepOut : boolean**
-          - `#!json true` if vehicle should keep out of the geofenced area. `#!json false`
-          otherwise.
 
 !!! info "Requires an [acknowledgement message][] from the vehicle."
 
@@ -144,6 +128,35 @@ plane should either loiter or land to the ground). Vehicles should continue to s
   "time": <unsigned 64-bit integer>,
 }
 ```
+
+----------------------------------------------------------------------------------------------------
+
+## Geofence Message
+
+Sent to the vehicle to send geofencing coordinates for the keep-in and keep-out zones of the mission.
+
+```javascript
+{
+  "type": "geofence",
+  "id": <unsigned 32-bit integer>,
+  "sid": <unsigned 32-bit integer>,
+  "tid": <unsigned 32-bit integer>,
+  "time": <unsigned 64-bit integer>,
+  "geofence" {
+    "keepOut": [<float>, <float>][],
+    "keepIn": [<float>, <float>][]
+  }
+}
+```
+
+  - **geofence**
+      - **keepOut : [float, float][]**
+          - Array of structure `[latitude, longitude]` for all four corners of the box.
+
+      - **keepIn : [float, float][]**
+          - Array of structure `[latitude, longitude]` for all four corners of the box.
+
+!!! info "Requires an [acknowledgement message][] from the vehicle."
 
 ----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
 ## Why is the change being made?

This change is made because GCS needs a new message to handle Geofencing information outside of the start message. This change is not _necessary,_ but it improves scalability for future use of GCS.

 ## What has changed to address the problem?

This change created a new GeofenceMessage containing geofencing values that can be sent to all vehicles. StartMessage was changed as well by deleting the geofencing parameters that was in it previously.

 ## How was this change tested?

This change was tested using `npm test`.