### PR TITLE
Add docs for including ts/tsx files in eslint atom

### DIFF
--- a/docs/communications/messages/gcs-vehicles-messages.md
+++ b/docs/communications/messages/gcs-vehicles-messages.md
@@ -133,7 +133,8 @@ plane should either loiter or land to the ground). Vehicles should continue to s
 
 ## Geofence Message
 
-Sent to the vehicle to send geofencing coordinates for the keep-in and keep-out zones of the mission.
+Sent to the vehicle to send geofencing coordinates for the keep-in and keep-out zones of the
+mission.
 
 ```javascript
 {

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -65,7 +65,11 @@ Set the following settings to configure your Atom text editor for this project. 
 project have 100 characters max.
 
   - Set `Settings > Editor > Preferred Line Length` to 100
+
   - Keep `Settings > Editor > Soft Wrap` unchecked
+
+  - Add `source.ts` and `source.tsx` to the list of supported extensions in
+  `Settings > Packages > linter-eslint > List of scopes to run ESLint on`
 
 ### MkDocs documentation packages
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:lint": "npm run test:eslint && npm run test:stylelint && npm run test:remarklint",
     "test:eslint": "eslint --ext .js,.jsx,.ts,.tsx \".\"",
     "test:stylelint": "stylelint \"**/*.css\"",
-    "test:remarklint": "remark .",
+    "test:remarklint": "remark . --frail",
     "test:types": "tsc --project . --outDir dist --pretty",
     "test:unit": "nyc mocha --require ts-node/register test/**/*.test.ts",
     "coverage": "nyc report --reporter=text-lcov | coveralls",


### PR DESCRIPTION
This change adds docs to include ts and tsx files to be linted by
`linter-eslint` atom plugin.

This change was tested with `npm test`. The `--frail` option was added
to the `test:remarklint` command to throw errors if any issues are found
(instead of quietly warning).

Fixes #107