### PR TITLE
Fix acknowledgement note on connectionAck messages

### DIFF
--- a/docs/communications/messages/gcs-vehicles-messages.md
+++ b/docs/communications/messages/gcs-vehicles-messages.md
@@ -19,7 +19,7 @@ field for messages, which directly relates to this message [here](../implementat
 }
 ```
 
-!!! warning "Should not be acknowledged."
+!!! info "Requires an [acknowledgement message][] from the vehicle."
 
 ----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Prior to this change, the wiki showed incorrect acknowledgement information about the connection acknowledgement messages. Connection acknowledgement messages are supposed to be acknowledged (as of right now).

This change makes connection acknowledgement message require an acknowledgement.

*in the future I plan to remove connection acknowledgement messages entirely but the wiki should be accurate of what the protocol is today*