### PR TITLE
Add support to save console log as a .log file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GCS",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "license": "MIT",
   "author": "Northrop Grumman Collaboration Project",
   "description": "Ground Control Station for autonomous vehicle platforms in NGCP",

--- a/src/renderer/mainWindow/log/LogContainer.tsx
+++ b/src/renderer/mainWindow/log/LogContainer.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-virtualized';
 
 import * as ComponentStyle from '../../../types/componentStyle';
+import ipc from '../../../util/ipc';
 
 import Select from '../../common/Select';
 
@@ -93,6 +94,7 @@ export default class LogContainer extends Component<ComponentStyle.ThemeProps, S
     this.onRowsRenderered = this.onRowsRenderered.bind(this);
     this.rowRenderer = this.rowRenderer.bind(this);
     this.clearMessages = this.clearMessages.bind(this);
+    this.saveMessages = this.saveMessages.bind(this);
     this.updateFilter = this.updateFilter.bind(this);
     this.logMessages = this.logMessages.bind(this);
 
@@ -231,6 +233,18 @@ export default class LogContainer extends Component<ComponentStyle.ThemeProps, S
     this.onRowsRenderered();
   }
 
+  /**
+   * Combine the messages in the right format then pass it to postSaveLog.
+   */
+  private saveMessages(): void {
+    const { messages } = this.state;
+    let log = '';
+    messages.forEach((message): void => {
+      log += `${(message.time as Moment).format('YYYY-MM-DD HH:mm:ss.SSS')} - ${message.type} - ${message.message}\n`;
+    });
+    ipc.postSaveLog(log);
+  }
+
   public render(): ReactNode {
     const { theme } = this.props;
     const { filteredMessages } = this.state;
@@ -273,6 +287,7 @@ export default class LogContainer extends Component<ComponentStyle.ThemeProps, S
             }]}
           />
           <button type="button" onClick={this.clearMessages}>Clear Log</button>
+          <button type="button" onClick={this.saveMessages}>Save Log</button>
         </div>
       </div>
     );

--- a/src/util/ipc.ts
+++ b/src/util/ipc.ts
@@ -258,6 +258,16 @@ function postSaveConfig(
 }
 
 /**
+ * Post "saveLog" notification.
+ *
+ * Files that take this notification:
+ * - src/main/index
+ */
+function postSaveLog(log: string): void {
+  ipcRenderer.send('post', 'saveLog', log);
+}
+
+/**
  * Post "sendMessage" notification.
  *
  * Files that take this notification:
@@ -506,6 +516,7 @@ export default {
   postReceiveMessage,
   postResumeMission,
   postSaveConfig,
+  postSaveLog,
   postSendMessage,
   postSetMapToUserLocation,
   postShowMissionWindow,


### PR DESCRIPTION
 ## Why is the change being made?

This change is made to address issue #53 as it is needed for improvement
of the application. Closes #53.

 ## What has changed to address the problem?

To address the problem, a Save Log button was created next to
the Clear Log button in the LogContainer. This button calls saveMessages
which preprocess the log messages as a string then pass it to
ipc.postSaveLog. Then postSaveLog passes the messages to saveLog function
in index.ts through ipcRenderer.

 ## How was this change tested?

This change was tested with npm test.